### PR TITLE
don't error when rerunning postinstall download script

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-[ `uname` == "Linux" ] || { echo "Only Linux OS is supported."; exit 1; }
-[ -s "source-data.zip" ] && exit 0;
-
 VERSION=18b
 OUT_DIR=source-data
-curl http://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/gdelx_$VERSION.zip -o source-data.zip
-unzip source-data.zip -d $OUT_DIR && rm source-data.zip
+TMP_FILE_NAME=source-data.zip
+
+[ `uname` == "Linux" ] || { echo "Only Linux OS is supported."; exit 1; }
+[ -d "$OUT_DIR" ] && exit 0;
+[ -s "$TMP_FILE_NAME" ] || curl http://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/gdelx_$VERSION.zip -o "$TMP_FILE_NAME"
+unzip "$TMP_FILE_NAME" -nq -d "$OUT_DIR" && rm "$TMP_FILE_NAME"


### PR DESCRIPTION
This fixes errors that would happen if you run `npm install` or `yarn` more than once with this in the project, which we seldom saw since we download and build this in a container! But it does make development a bit easier.