### PR TITLE
follow redirects in download script, bump version -> 2.0.14

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -6,4 +6,4 @@ TMP_FILE_NAME=source-data.zip
 [ `uname` == "Linux" ] || { echo "Only Linux OS is supported."; exit 1; }
 [ -d "$OUT_DIR" ] && exit 0;
 [ -s "$TMP_FILE_NAME" ] || curl http://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/gdelx_$VERSION.zip -o "$TMP_FILE_NAME"
-unzip "$TMP_FILE_NAME" -nq -d "$OUT_DIR" && rm "$TMP_FILE_NAME"
+unzip -nq "$TMP_FILE_NAME" -d "$OUT_DIR" && rm "$TMP_FILE_NAME"

--- a/download.sh
+++ b/download.sh
@@ -5,5 +5,5 @@ TMP_FILE_NAME=source-data.zip
 
 [ `uname` == "Linux" ] || { echo "Only Linux OS is supported."; exit 1; }
 [ -d "$OUT_DIR" ] && exit 0;
-[ -s "$TMP_FILE_NAME" ] || curl http://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/gdelx_$VERSION.zip -o "$TMP_FILE_NAME"
+[ -s "$TMP_FILE_NAME" ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/gdelx_$VERSION.zip -o "$TMP_FILE_NAME"
 unzip -nq "$TMP_FILE_NAME" -d "$OUT_DIR" && rm "$TMP_FILE_NAME"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc-geosupport",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Node bindings for NYC DoITT's geosupport package, providing geocoding capabilities for NYC addresses.",
   "main": "./dist/index.js",
   "types": "./dist/module.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc-geosupport",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Node bindings for NYC DoITT's geosupport package, providing geocoding capabilities for NYC addresses.",
   "main": "./dist/index.js",
   "types": "./dist/module.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc-geosupport",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Node bindings for NYC DoITT's geosupport package, providing geocoding capabilities for NYC addresses.",
   "main": "./dist/index.js",
   "types": "./dist/module.d.ts",


### PR DESCRIPTION
This fixes package installation, required in order to build a new geocoder image. Failures are because data path points to a 3XX redirect, which cURL needs to be instructed to follow.