### PR TITLE
update geosupport data to version 19A

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-LD_LIBRARY_PATH=./source-data/version-18b_18.2/lib/
-GEOFILES=./source-data/version-18b_18.2/fls/
+LD_LIBRARY_PATH=./source-data/version-18c_18.3/lib/
+GEOFILES=./source-data/version-18c_18.3/fls/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _Based on the initial work done by
 
 This package is a barebones interface to the Geosupport library bindings, using Character-Only Work Areas (COWs).
 For full detailed information on the different functions, fields, and interpreting their values, see
-[the Geosupport User Programming Guide](http://www1.nyc.gov/assets/planning/download/pdf/data-maps/open-data/upg.pdf?r=18b),
+[the Geosupport User Programming Guide](http://www1.nyc.gov/assets/planning/download/pdf/data-maps/open-data/upg.pdf?r=18c),
 which include COW tables in the appendix.
 
 After installation, the binary source data is downloaded (see [download.js](download.js)).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _Based on the initial work done by
 
 This package is a barebones interface to the Geosupport library bindings, using Character-Only Work Areas (COWs).
 For full detailed information on the different functions, fields, and interpreting their values, see
-[the Geosupport User Programming Guide](http://www1.nyc.gov/assets/planning/download/pdf/data-maps/open-data/upg.pdf?r=18c),
+[the Geosupport User Programming Guide](http://www1.nyc.gov/assets/planning/download/pdf/data-maps/open-data/upg.pdf?r=19a),
 which include COW tables in the appendix.
 
 After installation, the binary source data is downloaded (see [download.js](download.js)).

--- a/download.sh
+++ b/download.sh
@@ -5,7 +5,7 @@ OUT_DIR=source-data
 mkdir -p $OUT_DIR
 
 [ -s geosupport-base.zip ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo19a_191.zip -o geosupport-base.zip
-unzip -nq geosupport-base.zip -d "$OUT_DIR" && rm geosupport-base.zip 'version-19a_19.1/*'
+unzip -nq geosupport-base.zip -d "$OUT_DIR" 'version-19a_19.1/*' && rm geosupport-base.zip
 
 [ -s geosupport-data.zip ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_upad_tpad_19a3.zip -o geosupport-data.zip
 unzip -oq geosupport-data.zip -d "$OUT_DIR/fls" && rm geosupport-data.zip

--- a/download.sh
+++ b/download.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-VERSION=18b
 OUT_DIR=source-data
 TMP_FILE_NAME=source-data.zip
 
 [ `uname` == "Linux" ] || { echo "Only Linux OS is supported."; exit 1; }
-[ -d "$OUT_DIR" ] && exit 0;
-[ -s "$TMP_FILE_NAME" ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/gdelx_$VERSION.zip -o "$TMP_FILE_NAME"
-unzip -nq "$TMP_FILE_NAME" -d "$OUT_DIR" && rm "$TMP_FILE_NAME"
+mkdir -p $OUT_DIR
+
+[ -s geosupport-base.zip ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/gdelx_18c.zip -o geosupport-base.zip
+unzip -nq geosupport-base.zip -d "$OUT_DIR" && rm geosupport-base.zip
+
+[ -s geosupport-data.zip ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_upad_tpad_19a3.zip -o geosupport-data.zip
+unzip -oq geosupport-data.zip -d "$OUT_DIR/version-18c_18.3/fls" && rm geosupport-data.zip

--- a/download.sh
+++ b/download.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-OUT_DIR=source-data
-TMP_FILE_NAME=source-data.zip
-
 [ `uname` == "Linux" ] || { echo "Only Linux OS is supported."; exit 1; }
+
+OUT_DIR=source-data
 mkdir -p $OUT_DIR
 
-[ -s geosupport-base.zip ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/gdelx_18c.zip -o geosupport-base.zip
-unzip -nq geosupport-base.zip -d "$OUT_DIR" && rm geosupport-base.zip
+[ -s geosupport-base.zip ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo19a_191.zip -o geosupport-base.zip
+unzip -nq geosupport-base.zip -d "$OUT_DIR" && rm geosupport-base.zip 'version-19a_19.1/*'
 
 [ -s geosupport-data.zip ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_upad_tpad_19a3.zip -o geosupport-data.zip
-unzip -oq geosupport-data.zip -d "$OUT_DIR/version-18c_18.3/fls" && rm geosupport-data.zip
+unzip -oq geosupport-data.zip -d "$OUT_DIR/fls" && rm geosupport-data.zip

--- a/download.sh
+++ b/download.sh
@@ -2,10 +2,11 @@
 [ `uname` == "Linux" ] || { echo "Only Linux OS is supported."; exit 1; }
 
 OUT_DIR=source-data
-mkdir -p $OUT_DIR
+mkdir -p "$OUT_DIR"
 
 [ -s geosupport-base.zip ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_geo19a_191.zip -o geosupport-base.zip
-unzip -nq geosupport-base.zip -d "$OUT_DIR" 'version-19a_19.1/*' && rm geosupport-base.zip
+unzip -nq geosupport-base.zip && rm geosupport-base.zip
+mv version-19a_19.1/* -t "$OUT_DIR"
 
 [ -s geosupport-data.zip ] || curl -L https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/linux_upad_tpad_19a3.zip -o geosupport-data.zip
 unzip -oq geosupport-data.zip -d "$OUT_DIR/fls" && rm geosupport-data.zip

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc-geosupport",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "description": "Node bindings for NYC DoITT's geosupport package, providing geocoding capabilities for NYC addresses.",
   "main": "./dist/index.js",
   "types": "./dist/module.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc-geosupport",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Node bindings for NYC DoITT's geosupport package, providing geocoding capabilities for NYC addresses.",
   "main": "./dist/index.js",
   "types": "./dist/module.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc-geosupport",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "Node bindings for NYC DoITT's geosupport package, providing geocoding capabilities for NYC addresses.",
   "main": "./dist/index.js",
   "types": "./dist/module.d.ts",


### PR DESCRIPTION
This update was a little less straightforward than the previous ones, since they changed the URL of the download ZIP. Still available, after a little digging! Also added is logic to download and apply the TPAD/UPAD updates (updates may occur more frequently than the quarterly releases of geosupport itself), and the geocoder will be able to decouple itself from the particular data version number here.